### PR TITLE
Added "position" to TakeProfitStep order. 

### DIFF
--- a/XCommas.Net/XCommas.Net/Objects/SmartTradeCreateParameters.cs
+++ b/XCommas.Net/XCommas.Net/Objects/SmartTradeCreateParameters.cs
@@ -47,6 +47,9 @@ namespace XCommas.Net.Objects
 
     public class SmartTradeUpdateParameters : SmartTradeParametersBase
     {
+        [JsonProperty("smart_trade_id")]
+        public int SmartTradeId { get; set; }
+
         [JsonProperty("average_buy_price")]
         public decimal? AverageBuyPrice { get; set; }
         [JsonProperty("buy_price")]

--- a/XCommas.Net/XCommas.Net/Objects/TakeProfitStepOrder.cs
+++ b/XCommas.Net/XCommas.Net/Objects/TakeProfitStepOrder.cs
@@ -5,14 +5,17 @@ namespace XCommas.Net.Objects
 {
     public class TakeProfitStepOrder
     {
+        [JsonProperty("position")]
+        public int Position { get; set; }
+
         [JsonProperty("percent")]
-        public double Percent { get; set; }
+        public decimal Percent { get; set; }
         [JsonProperty("price")]
-        public double? Price { get; set; }
+        public decimal? Price { get; set; }
         [JsonConverter(typeof(StringEnumConverter))]
         [JsonProperty("price_method")]
         public PriceMethod? PriceMethod { get; set; }
         [JsonProperty("price_percentage")]
-        public double? PricePercentage { get; set; }
+        public decimal? PricePercentage { get; set; }
     }
 }


### PR DESCRIPTION
-TakeProfitStepOrder.cs "price", "price_percentage" and "percent" properties changed from double to decimal.
-TakeProfitStepOrder.cs  added "position" variable. (Required to update trades that have multiple take profit orders.)
-SmartTradeCreateParameters.cs added "smart_trade_id" property.