### PR TITLE
Fixed TakeProfitType and added StartOrderType property

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ var data = new BotData
     Name = "My new bot",
     TrailingEnabled = true,
     TrailingDeviation = 1.0m,
+    StartOrderType = StartOrderType.Limit,
     Strategies = new BotStrategy[]
     {
         new QflBotStrategy
@@ -386,6 +387,7 @@ var data = new BotData
     MaxActiveDeals = 1,
     ProfitCurrency = ProfitCurrency.QuoteCurrency,
     SafetyOrderStepPercentage = 2.5m,
+    StartOrderType = StartOrderType.Limit,
     MaxSafetyOrders = 2,
     TakeProfitType = TakeProfitType.Total,
     TakeProfit = 1.5m,

--- a/XCommas.Net/XCommas.Net/Objects/Bot.cs
+++ b/XCommas.Net/XCommas.Net/Objects/Bot.cs
@@ -35,9 +35,6 @@ namespace XCommas.Net.Objects
         public int AccountId { get; set; }
         [JsonProperty("is_enabled")]
         public bool IsEnabled { get; set; }
-        [JsonConverter(typeof(StringEnumConverter), typeof(TakeProfitTypeNamingStrategy))]
-        [JsonProperty("take_profit_type")]
-        public new TakeProfitType TakeProfitType { get; set; }
     }
 
     public class BotUpdateData : BotData

--- a/XCommas.Net/XCommas.Net/Objects/Bot.cs
+++ b/XCommas.Net/XCommas.Net/Objects/Bot.cs
@@ -63,6 +63,7 @@ namespace XCommas.Net.Objects
             this.SafetyOrderStepPercentage = data.SafetyOrderStepPercentage;
             this.SafetyOrderVolume = data.SafetyOrderVolume;
             this.SafetyOrderVolumeType = data.SafetyOrderVolumeType;
+            this.StartOrderType = data.StartOrderType;
             this.StopLossPercentage = data.StopLossPercentage;
             this.Strategies = data.Strategies;
             this.TakeProfit = data.TakeProfit;
@@ -97,6 +98,7 @@ namespace XCommas.Net.Objects
             this.SafetyOrderStepPercentage = data.SafetyOrderStepPercentage;
             this.SafetyOrderVolume = data.SafetyOrderVolume;
             this.SafetyOrderVolumeType = data.SafetyOrderVolumeType;
+            this.StartOrderType = data.StartOrderType;
             this.StopLossPercentage = data.StopLossPercentage;
             this.Strategies = data.Strategies;
             this.TakeProfit = data.TakeProfit;
@@ -171,6 +173,9 @@ namespace XCommas.Net.Objects
         public LeverageType LeverageType { get; set; }
         [JsonProperty("leverage_custom_value")]
         public int? LeverageCustomValue { get; set; }
+        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonProperty("start_order_type")]
+        public StartOrderType StartOrderType { get; set; }
 
     }
 }

--- a/XCommas.Net/XCommas.Net/Objects/StartOrderType.cs
+++ b/XCommas.Net/XCommas.Net/Objects/StartOrderType.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.Serialization;
+
+namespace XCommas.Net.Objects
+{
+    public enum StartOrderType
+    {
+        [EnumMember(Value = "limit")]
+        Limit,
+        [EnumMember(Value = "market")]
+        Market
+    }
+}


### PR DESCRIPTION
This PR fixes an issue with TakeProfitType #9 and it will allow us to set StartOrderType to Market/Limit #10

![image](https://user-images.githubusercontent.com/16029585/92655032-0bf70680-f2f1-11ea-8884-e57aeed5c9b9.png)
