### PR TITLE
Added Grid Bots

### DIFF
--- a/XCommas.Net/XCommas.Net/Objects/GridBot.cs
+++ b/XCommas.Net/XCommas.Net/Objects/GridBot.cs
@@ -40,20 +40,6 @@ namespace XCommas.Net.Objects
         public decimal InvestmentBaseCurrency { get; set; }
         [JsonProperty("investment_quote_currency")]
         public decimal InvestmentQuoteCurrency { get; set; }
-        //[JsonProperty("grid_lines")]
-        //public GridLine GridLines { get; set; }
-    }
-
-    public class GridBotProfit
-    {
-        [JsonProperty("grid_line_id")]
-        public int GridLineId { get; set; }
-        [JsonProperty("profit")]
-        public decimal Profit { get; set; }
-        [JsonProperty("usd_profit")]
-        public decimal UsdProfit { get; set; }
-        [JsonProperty("created_at")]
-        public DateTime CreatedAt { get; set; }
     }
 
     public class GridBotCreateData : GridBotData

--- a/XCommas.Net/XCommas.Net/Objects/GridBot.cs
+++ b/XCommas.Net/XCommas.Net/Objects/GridBot.cs
@@ -1,0 +1,116 @@
+﻿using Newtonsoft.Json;
+using System;
+using Newtonsoft.Json.Converters;
+
+namespace XCommas.Net.Objects
+{
+    public class GridBot : GridBotData
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+        [JsonProperty("account_id")]
+        public int AccountId { get; set; }
+        [JsonProperty("account_name")]
+        public string AccountName { get; set; }
+        [JsonProperty("is_enabled")]
+        public bool IsEnabled { get; set; }
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+        [JsonProperty("updated_at")]
+        public DateTime UpdatedAt { get; set; }
+        [JsonProperty("name")]
+        public string Name { get; set; }
+        [JsonProperty("start_price")]
+        public decimal StartPrice { get; set; }
+        [JsonProperty("grid_price_step")]
+        public decimal GridPriceStep { get; set; }
+        [JsonProperty("current_profit")]
+        public decimal CurrentProfit { get; set; }
+        [JsonProperty("current_profit_usd")]
+        public decimal CurrentProfitUsd { get; set; }
+        [JsonProperty("bought_volume")]
+        public decimal BoughtVolume { get; set; }
+        [JsonProperty("sold_volume")]
+        public decimal SoldVolume { get; set; }
+        [JsonProperty("profit_percentage")]
+        public decimal ProfitPercentage { get; set; }
+        [JsonProperty("current_price")]
+        public decimal CurrentPrice { get; set; }
+        [JsonProperty("investment_base_currency")]
+        public decimal InvestmentBaseCurrency { get; set; }
+        [JsonProperty("investment_quote_currency")]
+        public decimal InvestmentQuoteCurrency { get; set; }
+        //[JsonProperty("grid_lines")]
+        //public GridLine GridLines { get; set; }
+    }
+
+    public class GridBotProfit
+    {
+        [JsonProperty("grid_line_id")]
+        public int GridLineId { get; set; }
+        [JsonProperty("profit")]
+        public decimal Profit { get; set; }
+        [JsonProperty("usd_profit")]
+        public decimal UsdProfit { get; set; }
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+    }
+
+    public class GridBotCreateData : GridBotData
+    {
+        public GridBotCreateData(int accountId, GridBotData data)
+        {
+            AccountId = accountId;
+            QuantityPerGrid = data.QuantityPerGrid;
+            GridsQuantity = data.GridsQuantity;
+            LowerLimitPrice = data.LowerLimitPrice;
+            UpperLimitPrice = data.UpperLimitPrice;
+            LeverageCustomValue = data.LeverageCustomValue;
+            LeverageType = data.LeverageType;
+            Pair = data.Pair;
+        }
+
+        [JsonProperty("account_id")]
+        public int AccountId { get; set; }
+
+        [JsonProperty("is_enabled")]
+        public bool? IsEnabled { get; set; }
+    }
+
+    public class GridBotUpdateData : GridBotData
+    {
+        public GridBotUpdateData(int id, GridBotData data)
+        {
+            Id = id;
+            QuantityPerGrid = data.QuantityPerGrid;
+            GridsQuantity = data.GridsQuantity;
+            LowerLimitPrice = data.LowerLimitPrice;
+            UpperLimitPrice = data.UpperLimitPrice;
+            LeverageCustomValue = data.LeverageCustomValue;
+            LeverageType = data.LeverageType;
+            Pair = data.Pair;
+        }
+
+        [JsonProperty("id")]
+        public int Id { get; set; }
+    }
+
+    public class GridBotData
+    {
+        [JsonProperty("pair")]
+        public string Pair { get; set; }
+        [JsonProperty("upper_price")]
+        public decimal UpperLimitPrice { get; set; }
+        [JsonProperty("lower_price")]
+        public decimal LowerLimitPrice { get; set; }
+        [JsonProperty("quantity_per_grid")]
+        public decimal QuantityPerGrid { get; set; }
+        [JsonProperty("grids_quantity")]
+        public int GridsQuantity { get; set; }
+        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonProperty("leverage_type")]
+        public LeverageType? LeverageType { get; set; }
+        [JsonProperty("leverage_custom_value")]
+        public decimal? LeverageCustomValue { get; set; }
+    }
+}

--- a/XCommas.Net/XCommas.Net/Objects/TaPresetsType.cs
+++ b/XCommas.Net/XCommas.Net/Objects/TaPresetsType.cs
@@ -14,5 +14,7 @@ namespace XCommas.Net.Objects
         MFI_14_20,
         [EnumMember(Value = "CCI-40\u003c-200")]
         CCI_40_200,
+        [EnumMember(Value = "BB-20-1-UB")]
+        BB_20_1_UB
     }
 }

--- a/XCommas.Net/XCommas.Net/XCommasApi.cs
+++ b/XCommas.Net/XCommas.Net/XCommasApi.cs
@@ -616,7 +616,7 @@ namespace XCommas.Net
             }
             catch(Exception ex)
             {
-                return new XCommasResponse<T>(default(T), validatedResponse.RawData, $"Could not serialize json to {typeof(T).Name} : {ex.ToString()}  json data: {validatedResponse.RawData}");
+                return new XCommasResponse<T>(default(T), validatedResponse.RawData, $"Could not serialize json to {typeof(T).Name} : {ex.ToString()}");
             }
         }
 

--- a/XCommas.Net/XCommas.Net/XCommasApi.cs
+++ b/XCommas.Net/XCommas.Net/XCommasApi.cs
@@ -221,6 +221,80 @@ namespace XCommas.Net
 
         #endregion
 
+        #region Grid Bots
+        
+        public XCommasResponse<GridBot[]> GetGridBots(int limit = 10, int? offset = null, int[] accountIds = null, string accountTypes = null, BotScope botState = BotScope.Enabled, string sortBy = "bot_id", string sortDirection = "asc") => this.GetGridBotsAsync(limit, offset, accountIds, accountTypes, botState, sortBy, sortDirection).Result;
+        public async Task<XCommasResponse<GridBot[]>> GetGridBotsAsync(int limit = 10, int? offset = null, int[] accountIds = null, string accountTypes = null, BotScope botState = BotScope.Enabled, string sortBy = "bot_id", string sortDirection = "asc")
+        {
+            var path = $"{BaseAddress}/ver1/grid_bots?limit={limit}&offset={offset}&state={botState.GetEnumMemberAttrValue()}&sort_by={sortBy}&sort_direction={sortDirection}";
+            using (var request = XCommasRequest.Get(path).Sign(this))
+            {
+                return await this.GetResponse<GridBot[]>(request).ConfigureAwait(false);
+            }
+        }
+
+        public XCommasResponse<GridBot> CreateGridBot(int accountId, GridBotData data) => this.CreateGridBotAsync(accountId, data).Result;
+        public async Task<XCommasResponse<GridBot>> CreateGridBotAsync(int accountId, GridBotData data)
+        {
+            var path = $"{BaseAddress}/ver1/grid_bots/manual";
+            using (var request = XCommasRequest.Post(path).WithSerializedContent(new GridBotCreateData(accountId, data)).Sign(this))
+            {
+                return await this.GetResponse<GridBot>(request).ConfigureAwait(false);
+            }
+        }
+
+        public XCommasResponse<GridBot> UpdateGridBot(int gridBotId, GridBotData data) => this.UpdateGridBotAsync(gridBotId, data).Result;
+        public async Task<XCommasResponse<GridBot>> UpdateGridBotAsync(int gridBotId, GridBotData data)
+        {
+            var path = $"{BaseAddress}/ver1/grid_bots/{gridBotId}/manual";
+            using (var request = XCommasRequest.Patch(path).WithSerializedContent(new GridBotUpdateData(gridBotId, data)).Sign(this))
+            {
+                return await this.GetResponse<GridBot>(request).ConfigureAwait(false);
+            }
+        }
+
+        public XCommasResponse<GridBot> DisableGridBot(int gridBotId) => this.DisableGridBotAsync(gridBotId).Result;
+        public async Task<XCommasResponse<GridBot>> DisableGridBotAsync(int gridBotId)
+        {
+            var path = $"{BaseAddress}/ver1/grid_bots/{gridBotId}/disable";
+            using (var request = XCommasRequest.Post(path).Sign(this))
+            {
+                return await this.GetResponse<GridBot>(request).ConfigureAwait(false);
+            }
+        }
+
+        public XCommasResponse<GridBot> EnableGridBot(int gridBotId) => this.EnableGridBotAsync(gridBotId).Result;
+        public async Task<XCommasResponse<GridBot>> EnableGridBotAsync(int gridBotId)
+        {
+            var path = $"{BaseAddress}/ver1/grid_bots/{gridBotId}/enable";
+            using (var request = XCommasRequest.Post(path).Sign(this))
+            {
+                return await this.GetResponse<GridBot>(request).ConfigureAwait(false);
+            }
+        }
+
+        public XCommasResponse<bool> DeleteGridBot(int gridBotId) => this.DeleteGridBotAsync(gridBotId).Result;
+        public async Task<XCommasResponse<bool>> DeleteGridBotAsync(int gridBotId)
+        {
+            var path = $"{BaseAddress}/ver1/grid_bots/{gridBotId}/delete";
+            using (var request = XCommasRequest.Post(path).Sign(this))
+            {
+                return await this.GetResponse<bool>(request).ConfigureAwait(false);
+            }
+        }
+
+        public XCommasResponse<GridBot> ShowGridBot(int botId) => this.ShowGridBotAsync(botId).Result;
+        public async Task<XCommasResponse<GridBot>> ShowGridBotAsync(int botId)
+        {
+            var path = $"{BaseAddress}/ver1/grid_bots/{botId}";
+            using (var request = XCommasRequest.Get(path).Sign(this))
+            {
+                return await this.GetResponse<GridBot>(request).ConfigureAwait(false);
+            }
+        }
+
+        #endregion
+
         #region Bots
 
         public XCommasResponse<BotPairsBlackListData> GetBotPairsBlackList => this.GetBotPairsBlackListAsync().Result;
@@ -542,7 +616,7 @@ namespace XCommas.Net
             }
             catch(Exception ex)
             {
-                return new XCommasResponse<T>(default(T), validatedResponse.RawData, $"Could not serialize json to {typeof(T).Name} : {ex.ToString()}");
+                return new XCommasResponse<T>(default(T), validatedResponse.RawData, $"Could not serialize json to {typeof(T).Name} : {ex.ToString()}  json data: {validatedResponse.RawData}");
             }
         }
 


### PR DESCRIPTION
New methods to manage grid bots:

- create
- update
- delete
- enable
- disable
- show
- list

Also added a new TA Preset Type. This Preset Type can be in use by older bots.