### PR TITLE
Added StopLoss values to object Deal

### DIFF
--- a/XCommas.Net/XCommas.Net/Objects/Deal.cs
+++ b/XCommas.Net/XCommas.Net/Objects/Deal.cs
@@ -113,5 +113,15 @@ namespace XCommas.Net.Objects
         public decimal? TrailingMaxPrice { get; set; }
         [JsonProperty("bot_events")]
         public BotEvent[] BotEvents { get; set; }
+        [JsonProperty("stop_loss_timeout_enabled")]
+        public bool StopLossTimeoutEnabled { get; set; }
+        [JsonProperty("stop_loss_timeout_in_seconds")]
+        public int StopLossTimeoutInSeconds { get; set; }
+        [JsonProperty("stop_loss_percentage")]
+        public decimal? StopLossPercentage { get; set; }
+        [JsonProperty("stop_loss_type")]
+        public StopLossType StopLossType { get; set; }
+        [JsonProperty("stop_loss_price")]
+        public decimal? StopLossPrice { get; set; }
     }
 }

--- a/XCommas.Net/XCommas.Net/XCommas.Net.csproj
+++ b/XCommas.Net/XCommas.Net/XCommas.Net.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewtonSoft.Json" Version="12.0.3" />
+    <PackageReference Include="NewtonSoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net472'">
     <Reference Include="System" />

--- a/XCommas.Net/XCommas.Net/XCommas.Net.csproj
+++ b/XCommas.Net/XCommas.Net/XCommas.Net.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewtonSoft.Json" Version="13.0.1" />
+    <PackageReference Include="NewtonSoft.Json" Version="12.0.3" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net472'">
     <Reference Include="System" />


### PR DESCRIPTION
Hello,

I was building a PoC to simulate TSL in bot's deals and saw that you were missing the stop loss properties from the Deal object in Objects/Deal.cs

I have tested it on my PoC and works fine. I will now build my app with the forked DLL but I figured I might as well create the PR for you.

Great job btw! Thank you for creating 3Commas.Net.
Sorry I also updated Newtonsoft.Json, my VStudio just did that on its own. Feel free to remove it.