### PR TITLE
Allow usage of IHttpClientFactory

### DIFF
--- a/XCommas.Net/XCommas.Net/XCommas.Net.csproj
+++ b/XCommas.Net/XCommas.Net/XCommas.Net.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net45;net46;net47;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net47;net472</TargetFrameworks>
     <RootNamespace>XCommas.Net</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/TheKimono/3Commas.Net.git</RepositoryUrl>
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="NewtonSoft.Json" Version="12.0.3" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net472'">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
@@ -30,5 +30,25 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="Microsoft.Extensions.Http">
+      <Version>5.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.Http">
+      <Version>5.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
+    <PackageReference Include="Microsoft.Extensions.Http">
+      <Version>5.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="Microsoft.Extensions.Http">
+      <Version>5.0.0</Version>
+    </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Currently a new HttpClient instance will be created for each request and this will result in lots of unreleased connections.

We can now pass an IHttpClientFactory to the constructor of XCommasApi. This parameter is optional, and if the factory is null, we will use a HttpClient Singleton for subsequent requests.


GetCurrencyRate Method has also been modified. The query string parameter "pretty_display_type" is deprecated and has been replaced by "market_code"