### PR TITLE
Feature/fix grid bot update

### DIFF
--- a/XCommas.Net/XCommas.Net/Objects/GridBot.cs
+++ b/XCommas.Net/XCommas.Net/Objects/GridBot.cs
@@ -18,8 +18,6 @@ namespace XCommas.Net.Objects
         public DateTime CreatedAt { get; set; }
         [JsonProperty("updated_at")]
         public DateTime UpdatedAt { get; set; }
-        [JsonProperty("name")]
-        public string Name { get; set; }
         [JsonProperty("start_price")]
         public decimal StartPrice { get; set; }
         [JsonProperty("grid_price_step")]
@@ -68,6 +66,7 @@ namespace XCommas.Net.Objects
         public GridBotUpdateData(int id, GridBotData data)
         {
             Id = id;
+            Name = data.Name;
             QuantityPerGrid = data.QuantityPerGrid;
             GridsQuantity = data.GridsQuantity;
             LowerLimitPrice = data.LowerLimitPrice;
@@ -83,6 +82,8 @@ namespace XCommas.Net.Objects
 
     public class GridBotData
     {
+        [JsonProperty("name")]
+        public string Name { get; set; }
         [JsonProperty("pair")]
         public string Pair { get; set; }
         [JsonProperty("upper_price")]

--- a/XCommas.Net/XCommas.Net/Objects/SmartTrades/OrderType.cs
+++ b/XCommas.Net/XCommas.Net/Objects/SmartTrades/OrderType.cs
@@ -7,7 +7,7 @@ namespace XCommas.Net.Objects.SmartTrades
         [EnumMember(Value = "market")]
         Market,
         [EnumMember(Value = "limit")]
-        Limit
+        Limit,
         [EnumMember(Value = "conditional")]
         Conditional
     }


### PR DESCRIPTION
After updating grid bots using UpdateGridBot() or UpdateGridBotAsync() the bot loses it's name. This seems to be a 3commas issue at the core, as the documentation states the property is not necessary.

In order to provide a quick fix for developers, instead of adressing this with 3commas, I'd suggest moving the "Name" property from the GridBot class to GridBotData which also serves as the DTO for updates.

According to the [docs](https://github.com/3commas-io/3commas-official-api-docs/blob/master/grid_bots_api.md#edit-grid-bot-manual-permission-bots_write-security-signed) it is possible to update a grid bot's name. So by just passing the name to the GridBotData from a previously fetched GridBot should fix the issue.